### PR TITLE
README.md 中的获取接口http://127.0.0.1:8000/select?name=douban 写成douban了

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ python runserver.py
 
 服务器提供接口
 ####获取
-http://127.0.0.1:8000/select?name=douban
+http://127.0.0.1:8000/select?name=free_ipproxy
 
 参数
 


### PR DESCRIPTION
README.md 中的获取接口http://127.0.0.1:8000/select?name=douban 写成douban了因而返回数据为空,改回free_ipproxy就可以了