### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,30 @@ database_config = {
 }
 ```
 
+## MYSQL数据库配置
+
+导入数据表结构
+```
+$ mysql> create database ipproxy;
+Query OK, 1 row affected (0.00 sec)
+$ mysql> use ipproxy;
+Database changed
+$ mysql> source '/你的项目目录/db.sql'
+
+```
+
 
 运行启动脚本 ipproxytool.py 也可以分别运行抓取，验证，服务器接口脚本，运行方法参考项目说明
 
 ```
-$ python ipproxytool.py
+$ python ipproxytool.py 
 ```
 
+新增异步验证方式，运行方法如下
+
+```
+$ python ipproxytool.py async
+```
 <br>
 
 ## 项目说明

--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ database_config = {
 }
 ```
 
-## MYSQL数据库配置
-
-导入数据表结构
+MYSQL: 导入数据表结构
 ```
 $ mysql> create database ipproxy;
 Query OK, 1 row affected (0.00 sec)

--- a/db.sql
+++ b/db.sql
@@ -78,6 +78,49 @@ LOCK TABLES `httpbin` WRITE;
 /*!40000 ALTER TABLE `httpbin` DISABLE KEYS */;
 /*!40000 ALTER TABLE `httpbin` ENABLE KEYS */;
 UNLOCK TABLES;
+
+--
+-- Dumping routines for database 'ipproxy'
+--
+/*!50003 DROP PROCEDURE IF EXISTS `drop_iptables` */;
+/*!50003 SET @saved_cs_client      = @@character_set_client */ ;
+/*!50003 SET @saved_cs_results     = @@character_set_results */ ;
+/*!50003 SET @saved_col_connection = @@collation_connection */ ;
+/*!50003 SET character_set_client  = utf8 */ ;
+/*!50003 SET character_set_results = utf8 */ ;
+/*!50003 SET collation_connection  = utf8_general_ci */ ;
+/*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
+/*!50003 SET sql_mode              = '' */ ;
+DELIMITER ;;
+CREATE DEFINER=`root`@`localhost` PROCEDURE `drop_iptables`()
+BEGIN
+   DELETE FROM ipproxy.free_ipproxy;
+   DELETE FROM ipproxy.httpbin;
+   TRUNCATE TABLE ipproxy.free_ipproxy;
+   TRUNCATE TABLE ipproxy.httpbin;
+END ;;
+DELIMITER ;
+/*!50003 SET sql_mode              = @saved_sql_mode */ ;
+/*!50003 SET character_set_client  = @saved_cs_client */ ;
+/*!50003 SET character_set_results = @saved_cs_results */ ;
+/*!50003 SET collation_connection  = @saved_col_connection */ ;
+/*!50003 DROP PROCEDURE IF EXISTS `ip_transfer` */;
+/*!50003 SET @saved_cs_client      = @@character_set_client */ ;
+/*!50003 SET @saved_cs_results     = @@character_set_results */ ;
+/*!50003 SET @saved_col_connection = @@collation_connection */ ;
+/*!50003 SET character_set_client  = utf8 */ ;
+/*!50003 SET character_set_results = utf8 */ ;
+/*!50003 SET collation_connection  = utf8_general_ci */ ;
+/*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
+/*!50003 SET sql_mode              = '' */ ;
+DELIMITER ;;
+CREATE DEFINER=`root`@`localhost` PROCEDURE `ip_transfer`(IN valid_id INT)
+BEGIN DECLARE cur_ip char(25); DECLARE cur_port int(4); SELECT ip,port INTO cur_ip,cur_port FROM free_ipproxy WHERE id = valid_id; DELETE FROM httpbin WHERE ip =cur_ip AND port = cur_port;  INSERT INTO httpbin(ip,port,country,anonymity,https,speed,source)  SELECT ip,port,country,anonymity,https,speed,source  FROM free_ipproxy WHERE id = valid_id; DELETE FROM free_ipproxy where id = valid_id; END ;;
+DELIMITER ;
+/*!50003 SET sql_mode              = @saved_sql_mode */ ;
+/*!50003 SET character_set_client  = @saved_cs_client */ ;
+/*!50003 SET character_set_results = @saved_cs_results */ ;
+/*!50003 SET collation_connection  = @saved_col_connection */ ;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -88,4 +131,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2018-01-24 13:38:56
+-- Dump completed on 2018-01-25  4:01:20

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,91 @@
+-- MySQL dump 10.13  Distrib 5.5.58, for Linux (x86_64)
+--
+-- Host: localhost    Database: ipproxy
+-- ------------------------------------------------------
+-- Server version	5.5.58
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `free_ipproxy`
+--
+
+DROP TABLE IF EXISTS `free_ipproxy`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `free_ipproxy` (
+  `id` int(8) NOT NULL AUTO_INCREMENT,
+  `ip` char(25) NOT NULL,
+  `port` int(4) NOT NULL,
+  `country` text,
+  `anonymity` int(2) DEFAULT NULL,
+  `https` char(4) DEFAULT NULL,
+  `speed` float DEFAULT NULL,
+  `source` char(20) DEFAULT NULL,
+  `save_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `vali_count` int(5) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `proxy_field` (`ip`,`port`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `free_ipproxy`
+--
+
+LOCK TABLES `free_ipproxy` WRITE;
+/*!40000 ALTER TABLE `free_ipproxy` DISABLE KEYS */;
+/*!40000 ALTER TABLE `free_ipproxy` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `httpbin`
+--
+
+DROP TABLE IF EXISTS `httpbin`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `httpbin` (
+  `id` int(8) NOT NULL AUTO_INCREMENT,
+  `ip` char(25) NOT NULL,
+  `port` int(4) NOT NULL,
+  `country` text,
+  `anonymity` int(2) DEFAULT NULL,
+  `https` char(4) DEFAULT NULL,
+  `speed` float DEFAULT NULL,
+  `source` char(20) DEFAULT NULL,
+  `save_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `vali_count` int(5) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `proxy_field` (`ip`,`port`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `httpbin`
+--
+
+LOCK TABLES `httpbin` WRITE;
+/*!40000 ALTER TABLE `httpbin` DISABLE KEYS */;
+/*!40000 ALTER TABLE `httpbin` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2018-01-24 13:38:56

--- a/ipproxytool.py
+++ b/ipproxytool.py
@@ -5,6 +5,7 @@ import os
 import sys
 import subprocess
 import run_validator
+import run_validator_async
 
 if __name__ == '__main__':
 
@@ -22,7 +23,11 @@ if __name__ == '__main__':
 
     subprocess.Popen(['python', 'run_crawl_proxy.py'])
     subprocess.Popen(['python', 'run_server.py'])
+    
+    if 'async' in sys.argv: 
+        run_validator_async.async_validator()
+    else:
+        run_validator.validator()
 
-    run_validator.validator()
 
 

--- a/run_crawl_proxy.py
+++ b/run_crawl_proxy.py
@@ -34,7 +34,6 @@ if __name__ == '__main__':
         format = '%(levelname)s %(asctime)s: %(message)s',
         level = logging.DEBUG
     )
-
     sql = SqlManager()
 
     spiders = [
@@ -43,21 +42,21 @@ if __name__ == '__main__':
         IpOneEightOneSpider,
         KuaiDaiLiSpider,  # 在访问前加了一个 js ，反爬
         GatherproxySpider,
-        HidemySpider,
+       # HidemySpider,  已失效
         ProxylistplusSpider,
         FreeProxyListsSpider,
         # PeulandSpider,  # 目标站点失效
         UsProxySpider,
         ProxyDBSpider,
     ]
-
     while True:
         utils.log('*******************run spider start...*******************')
-
-        sql.delete_old(config.free_ipproxy_table, 0.5)
-
-        for spider in spiders:
-            scrapydo.run_spider(spider_cls = spider)
-
+        #sql.delete_old(config.free_ipproxy_table, 0.5)
+        try:
+            for spider in spiders:
+                scrapydo.run_spider(spider_cls = spider)
+        except Exception as e:
+            utils.log('[Error]# spider goes wroing.Return Message: {}'.format(str(e)))
+     
         utils.log('*******************run spider waiting...*******************')
         time.sleep(1200)

--- a/run_validator.py
+++ b/run_validator.py
@@ -7,39 +7,32 @@ import sys
 import time
 import scrapydo
 import utils
+from importlib import import_module
 
-from ipproxytool.spiders.validator.douban import DoubanSpider
-from ipproxytool.spiders.validator.assetstore import AssetStoreSpider
-from ipproxytool.spiders.validator.gather import GatherSpider
-from ipproxytool.spiders.validator.httpbin import HttpBinSpider
-from ipproxytool.spiders.validator.steam import SteamSpider
-from ipproxytool.spiders.validator.boss import BossSpider
-from ipproxytool.spiders.validator.lagou import LagouSpider
-from ipproxytool.spiders.validator.liepin import LiepinSpider
-from ipproxytool.spiders.validator.jd import JDSpider
-from ipproxytool.spiders.validator.bbs import BBSSpider
-from ipproxytool.spiders.validator.zhilian import ZhiLianSpider 
-from ipproxytool.spiders.validator.amazoncn import AmazonCnSpider
+VALIDATORS = {'HttpBinSpider' :'ipproxytool.spiders.validator.httpbin',
+            # 'DoubanSpider':'ipproxytool.spiders.validator.douban',
+            # 'AssetStoreSpider':'ipproxytool.spiders.validator.assetstore',
+            # 'GatherSpider' :'ipproxytool.spiders.validator.gather',
+            # 'HttpBinSpider' :'ipproxytool.spiders.validator.httpbin',
+            # 'SteamSpider' :'ipproxytool.spiders.validator.steam',
+            # 'BossSpider' :'ipproxytool.spiders.validator.boss',
+            # 'LagouSpider' :'ipproxytool.spiders.validator.lagou',
+            # 'LiepinSpider' :'ipproxytool.spiders.validator.liepin',
+            # 'JDSpider' :'ipproxytool.spiders.validator.jd',
+            # 'BBSSpider' :'ipproxytool.spiders.validator.bbs',
+            # 'ZhiLianSpider' :'ipproxytool.spiders.validator.zhilian',
+            # 'AmazonCnSpider' :'ipproxytool.spiders.validator.amazoncn',
+              }
 
 scrapydo.setup()
 
-
 def validator():
-    validators = [
-        HttpBinSpider,  # 必须
-        # LagouSpider,
-        # BossSpider,
-        # LiepinSpider,
-        # JDSpider,
-        # DoubanSpider,
-        # BBSSpider,
-        # ZhiLianSpider,
-        # AmazonCnSpider,
-    ]
-
+     
     process_list = []
-    for validator in validators:
-        popen = subprocess.Popen(['python', 'run_spider.py', validator.name], shell = False)
+    for item, path in VALIDATORS.items():
+        module = import_module(path)
+        validator = getattr(module,item)
+        popen = subprocess.Popen(['python', 'run_spider.py', validator.name], shell=False)
         data = {
             'name': validator.name,
             'popen': popen,
@@ -56,16 +49,13 @@ def validator():
             if popen != None and popen.poll() == 0:
                 name = process.get('name')
                 utils.log('%(name)s spider finish...\n' % {'name': name})
-
                 process_list.remove(process)
-
                 p = subprocess.Popen(['python', 'run_spider.py', name], shell = False)
                 data = {
                     'name': name,
                     'popen': p,
                 }
                 process_list.append(data)
-
                 time.sleep(1)
                 break
 

--- a/run_validator_async.py
+++ b/run_validator_async.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import sys
+import time
+import utils
+import aiohttp
+from aiohttp import ClientSession
+from sql.sql_manager import SqlManager
+import config
+import asyncio
+
+TEST_URL='http://httpbin.org/ip'
+
+async def test_connect(proxy,operator,mode=None):
+    conn = aiohttp.TCPConnector(verify_ssl=False)
+    async with ClientSession(connector=conn) as s:
+        try:
+            async with s.get(url=TEST_URL,proxy=proxy[2],
+                             timeout=10,allow_redirects=False) as resp:
+                page = await resp.text()
+                if (resp.status != 200 or str(resp.url) != TEST_URL):
+                    utils.log(('[INFO]#proxy:{ip} has been dropped\n'
+                               '      #Reason:Abnormal url or return Code').format(ip=proxy[1]))
+                    operator.del_proxy_with_id(config.free_ipproxy_table,proxy[0])
+                    operator.del_proxy_with_id(config.httpbin_table,proxy[0])
+                elif mode == 'add':
+                    operator.insert_valid_proxy(id=proxy[0])
+                else:
+                    operator.update_valid_proxy(id=proxy[0])
+                   
+        except Exception as e:
+            utils.log(('[INFO]#proxy:{ip} has been dropped\n'
+                       '      #Reason:{msg}').format(ip=proxy[1],msg=str(e)))
+            operator.del_proxy_with_id(config.free_ipproxy_table,proxy[0])
+            operator.del_proxy_with_id(config.httpbin_table,proxy[0])
+        finally:
+            operator.commit()
+
+
+def async_validator():
+    utils.log('[INFO]#Loading ip proxies....60 sec left')
+    time.sleep(60)
+    proxy_factory = SqlManager()
+    loop = asyncio.get_event_loop()
+    def test_process(table_name,mode=None,limit=50):
+        id_list = proxy_factory.get_proxy_ids(table_name) 
+        if len(id_list) > 0:
+            task_len = len(id_list)
+            cur_id = 0
+            for sig in range(0,task_len,limit):
+                proxies = proxy_factory.get_proxies_info(table_name=table_name,
+                                                         start_id=cur_id,
+                                                         limit=limit)
+                if len(proxies) == 0:
+                    break
+                cur_id = proxies[-1][0]
+                proxies = [[proxy[0],proxy[1],'http://{}:{}'.format(proxy[1],proxy[2])] for proxy in proxies]
+                tasks = [test_connect(proxy,proxy_factory,mode) for proxy in proxies]
+                loop.run_until_complete(asyncio.wait(tasks))
+    while True:
+        utils.log('[INFO]Validator process started')
+        utils.log('[INFO]Validator process:Verify mode start')
+        test_process(config.httpbin_table)
+        utils.log('[INFO]Validator process:Add mode start')
+        test_process(config.free_ipproxy_table,mode='add')
+        utils.log('[INFO]Validator process completed')
+        time.sleep(300)
+
+
+if __name__ == '__main__':
+    if not os.path.exists('log'):
+        os.makedirs('log')
+
+    logging.basicConfig(
+        filename = 'log/validator.log',
+        format = '%(asctime)s: %(message)s',
+        level = logging.INFO
+    )
+    async_validator()
+
+

--- a/server/dataserver.py
+++ b/server/dataserver.py
@@ -76,3 +76,16 @@ def delete():
     data = {'result': result}
 
     return json.dumps(data, indent=4)
+
+@app.route('/query')
+def query():
+    sql = SqlManager()
+    start_id = request.args.get('sid')
+    limit = int(request.args.get('limit','100'))
+    proxies = sql.get_proxies_info(config.httpbin_table,start_id=start_id,limit=limit)
+    data = [{'id':proxy[0],'ip':proxy[1],'port':proxy[2],'https':proxy[3]}
+            for proxy in proxies]
+    return json.dumps(data,indent=4)
+    
+
+    

--- a/sql/mysql.py
+++ b/sql/mysql.py
@@ -208,7 +208,7 @@ class MySql(SqlBase):
             包含id,ip,port信息的元组列表
 
         '''
-        command = ('SELECT id,ip,port from {table} where id >={start_id}'
+        command = ('SELECT id,ip,port,https from {table} where id >={start_id}'
                    ' order by id asc limit {limit}')
         command = command.format(table=table_name, start_id=start_id, limit=limit)
         proxies_info = []

--- a/sql/sql_manager.py
+++ b/sql/sql_manager.py
@@ -33,12 +33,18 @@ class SqlManager(object):
     def insert_proxy(self, table_name, proxy):
         return self.sql.insert_proxy(table_name, proxy)
 
+    def insert_valid_proxy(self,id=id):
+        return self.sql.insert_valid_proxy(id)
+ 
     def select_proxy(self, table_name, **kwargs):
         return self.sql.select_proxy(table_name, **kwargs)
 
     def update_proxy(self, table_name, proxy):
         return self.sql.update_proxy(table_name, proxy)
 
+    def update_valid_proxy(self,id=0):
+        return self.sql.update_valid_proxy(id=id)
+ 
     def delete_proxy(self, table_name, proxy):
         return self.sql.delete_proxy(table_name, proxy)
 
@@ -59,6 +65,9 @@ class SqlManager(object):
 
     def del_proxy_with_ip(self, table_name, ip):
         return self.sql.del_proxy_with_ip(table_name = table_name, ip = ip)
+
+    def get_proxies_info(self,table_name,start_id=0,limit=10):
+        return self.sql.get_proxies_info(table_name=table_name, start_id=start_id, limit=limit)
 
     def commit(self):
         return self.sql.commit()


### PR DESCRIPTION
1 增加异步筛选代理的方式，极大提高了当前筛选代理的速度
2 在异步筛选代理的运行方式下，增加MYSQL数据库表间的同步删除功能，优化筛选效率
3 优化run_crawl_spider程序中的库载入机制，采用动态库载入功能。
4 在README 中增加异步筛选机制的对应说明
MYSQL 优化：
1 增加表结构SQL创建语句， MYSQL数据库可直接利用SOURCE命令进行表结构创建
2 针对异步筛选代理，对数据库的结构进行优化，取消IP字段的UNIQ属性，以IP+Port组合在一起作为UNIQ键
3 增加数据库存储过程 
   3.1 drop_iptables()   清空httpbin和free_ipproxy数据，自增字段id重置
   3.2 ip_transfer(valid_id)    把free_ipproxy的数据转移至httpbin.
                              